### PR TITLE
Fixes an occasional deadlock

### DIFF
--- a/mockssh/server.py
+++ b/mockssh/server.py
@@ -42,14 +42,15 @@ class Handler(paramiko.ServerInterface):
             channel = self.transport.accept()
             if channel is None:
                 break
-            self.command_queues[channel.get_id()] = Queue()
+            if not channel.chanid in self.command_queues:
+                self.command_queues[channel.chanid] = Queue()
             t = threading.Thread(target=self.handle_client, args=(channel,))
             t.setDaemon(True)
             t.start()
 
     def handle_client(self, channel):
         try:
-            command = self.command_queues[channel.get_id()].get(block=True)
+            command = self.command_queues[channel.chanid].get(block=True)
             self.log.debug("Executing %s", command)
             p = subprocess.Popen(command, shell=True,
                                  stdin=subprocess.PIPE,

--- a/mockssh/test_server.py
+++ b/mockssh/test_server.py
@@ -50,13 +50,13 @@ def test_multiple_connections5(server):
 def _test_multiple_connections(server):
     # This test will deadlock without ea1e0f80aac7253d2d346732eefd204c6627f4c8
     fd, pkey_path = tempfile.mkstemp()
-    user, private_key = server._users.items()[0]
+    user, private_key = list(server._users.items())[0]
     open(pkey_path, 'w').write(open(private_key[0]).read())
     ssh_command = 'ssh -oStrictHostKeyChecking=no '
     ssh_command += "-i %s -p %s %s@localhost " % (pkey_path, server.port, user)
     ssh_command += 'echo hello'
     p = subprocess.check_output(ssh_command, shell=True)
-    assert p.strip() == 'hello'
+    assert p.decode('utf-8').strip() == 'hello'
 
 
 def test_invalid_user(server):

--- a/mockssh/test_server.py
+++ b/mockssh/test_server.py
@@ -1,5 +1,7 @@
 import codecs
 import platform
+import subprocess
+import tempfile
 
 from pytest import raises
 
@@ -23,6 +25,38 @@ def test_ssh_failed_commands(server):
             stderr = codecs.decode(stderr.read(), "utf8")
             assert (stderr.startswith("rm: cannot remove") or
                     stderr.startswith("rm: /: is a directory"))
+
+
+def test_multiple_connections1(server):
+    _test_multiple_connections(server)
+
+
+def test_multiple_connections2(server):
+    _test_multiple_connections(server)
+
+
+def test_multiple_connections3(server):
+    _test_multiple_connections(server)
+
+
+def test_multiple_connections4(server):
+    _test_multiple_connections(server)
+
+
+def test_multiple_connections5(server):
+    _test_multiple_connections(server)
+
+
+def _test_multiple_connections(server):
+    # This test will deadlock without ea1e0f80aac7253d2d346732eefd204c6627f4c8
+    fd, pkey_path = tempfile.mkstemp()
+    user, private_key = server._users.items()[0]
+    open(pkey_path, 'w').write(open(private_key[0]).read())
+    ssh_command = 'ssh -oStrictHostKeyChecking=no '
+    ssh_command += "-i %s -p %s %s@localhost " % (pkey_path, server.port, user)
+    ssh_command += 'echo hello'
+    p = subprocess.check_output(ssh_command, shell=True)
+    assert p.strip() == 'hello'
 
 
 def test_invalid_user(server):


### PR DESCRIPTION
I encountered an occasional deadlock when I was attempting to use mockssh using a real openssh client. I have observed that `self.command_queues[channel.chanid].get(block=True)` would block indefinitely and that the root of the problem appears to be that the `self.command_queues` dictionary would be filled with the same key multiple times. Just checking if the key already exists solved the deadlock problem for me (but I'm not sure this is a good solution).

I have included a unit test in 6a3025c that demonstrates this problem (I am running the test 5 times, since the problem does not always occur), if you revert 0dee748 the test should fail.

I am hoping you can include this PR or use the test case to find a better solution, as I would love to include MockSSH into another project for unit testing.
