### PR TITLE
sftp: add support for lstat and symlink

### DIFF
--- a/mockssh/sftp.py
+++ b/mockssh/sftp.py
@@ -92,7 +92,11 @@ class SFTPServerInterface(paramiko.SFTPServerInterface):
 
     @returns_sftp_error
     def symlink(self, src, dest):
-        os.symlink(src, dest)
+        try:
+            os.symlink(src, dest)
+        except OSError as e:
+            return SFTPServer.convert_errno(e.errno)
+
         return paramiko.SFTP_OK
 
     @returns_sftp_error

--- a/mockssh/sftp.py
+++ b/mockssh/sftp.py
@@ -86,6 +86,11 @@ class SFTPServerInterface(paramiko.SFTPServerInterface):
         return paramiko.SFTPAttributes.from_stat(st, path)
 
     @returns_sftp_error
+    def lstat(self, path):
+        st = os.lstat(path)
+        return paramiko.SFTPAttributes.from_stat(st, path)
+
+    @returns_sftp_error
     def remove(self, path):
         try:
             os.remove(path)

--- a/mockssh/sftp.py
+++ b/mockssh/sftp.py
@@ -91,6 +91,11 @@ class SFTPServerInterface(paramiko.SFTPServerInterface):
         return paramiko.SFTPAttributes.from_stat(st, path)
 
     @returns_sftp_error
+    def symlink(self, src, dest):
+        os.symlink(src, dest)
+        return paramiko.SFTP_OK
+
+    @returns_sftp_error
     def remove(self, path):
         try:
             os.remove(path)

--- a/mockssh/test_sftp.py
+++ b/mockssh/test_sftp.py
@@ -112,7 +112,6 @@ def test_rename(sftp_client, tmp_dir):
 
 @fixture(params=[("listdir_attr", "/"),
                  ("readlink", "/etc"),
-                 ("symlink", "/tmp/foo", "/tmp/bar"),
                  ("truncate", "/etc/passwd", 0),
                  ("utime", "/", (0, 0))])
 def unsupported_call(request):

--- a/mockssh/test_sftp.py
+++ b/mockssh/test_sftp.py
@@ -23,6 +23,15 @@ def test_get(sftp_client, tmp_dir):
     assert files_equal(target_fname, __file__)
 
 
+def test_symlink(sftp_client, tmp_dir):
+    foo = os.path.join(tmp_dir, "foo")
+    bar = os.path.join(tmp_dir, "bar")
+
+    open(foo, "w").write("foo")
+    sftp_client.symlink(foo, bar)
+    assert os.path.islink(bar)
+
+
 def test_lstat(sftp_client, tmp_dir):
     foo = os.path.join(tmp_dir, "foo")
     bar = os.path.join(tmp_dir, "bar")

--- a/mockssh/test_sftp.py
+++ b/mockssh/test_sftp.py
@@ -39,8 +39,9 @@ def test_lstat(sftp_client, tmp_dir):
     open(foo, "w").write("foo")
     os.symlink(foo, bar)
 
-    assert sftp_client.lstat(bar).st_size == 20
-    assert sftp_client.stat(bar).st_size == 3
+    stat = sftp_client.stat(bar)
+    lstat = sftp_client.lstat(bar)
+    assert stat.st_size != lstat.st_size
 
 
 def test_listdir(sftp_client, tmp_dir):

--- a/mockssh/test_sftp.py
+++ b/mockssh/test_sftp.py
@@ -23,6 +23,17 @@ def test_get(sftp_client, tmp_dir):
     assert files_equal(target_fname, __file__)
 
 
+def test_lstat(sftp_client, tmp_dir):
+    foo = os.path.join(tmp_dir, "foo")
+    bar = os.path.join(tmp_dir, "bar")
+
+    open(foo, "w").write("foo")
+    os.symlink(foo, bar)
+
+    assert sftp_client.lstat(bar).st_size == 20
+    assert sftp_client.stat(bar).st_size == 3
+
+
 def test_listdir(sftp_client, tmp_dir):
     open(os.path.join(tmp_dir, "foo"), "w").write("foo")
     open(os.path.join(tmp_dir, "bar"), "w").write("bar")
@@ -90,7 +101,6 @@ def test_rename(sftp_client, tmp_dir):
 
 
 @fixture(params=[("listdir_attr", "/"),
-                 ("lstat", "/"),
                  ("readlink", "/etc"),
                  ("symlink", "/tmp/foo", "/tmp/bar"),
                  ("truncate", "/etc/passwd", 0),


### PR DESCRIPTION
[DVC](https://github.com/iterative/dvc) uses `mock-ssh-server` to test some interactions with SSH, but it relies on `lstat` and `symlinks`. It would be great if we could merge this to master (others might find it useful :slightly_smiling_face:)