### PR TITLE
Added SFTPHandle stat method implementation

### DIFF
--- a/mockssh/sftp.py
+++ b/mockssh/sftp.py
@@ -27,6 +27,10 @@ class SFTPHandle(paramiko.SFTPHandle):
     def writefile(self):
         return self.file_obj
 
+    def stat(self):
+        st = os.fstat(self.file_obj.name)
+        return paramiko.SFTPAttributes.from_stat(st)
+
 
 LOG = logging.getLogger(__name__)
 

--- a/mockssh/sftp.py
+++ b/mockssh/sftp.py
@@ -28,7 +28,7 @@ class SFTPHandle(paramiko.SFTPHandle):
         return self.file_obj
 
     def stat(self):
-        st = os.fstat(self.file_obj.name)
+        st = os.fstat(self.file_obj.fileno())
         return paramiko.SFTPAttributes.from_stat(st)
 
 

--- a/mockssh/test_sftp.py
+++ b/mockssh/test_sftp.py
@@ -101,6 +101,15 @@ def test_chown(sftp_client, tmp_dir):
     sftp_client.chown(test_file, os.getuid(), os.getgid())
 
 
+def test_handle_stat(sftp_client, tmp_dir):
+    test_file = os.path.join(tmp_dir, "foo")
+    open(test_file, "w").write("X")
+
+    handle = sftp_client.open(test_file)
+    # only test if no exception occurs
+    handle.stat()
+
+
 def test_rename(sftp_client, tmp_dir):
     test_file = os.path.join(tmp_dir, "foo")
     open(test_file, "w").write("X")


### PR DESCRIPTION
Requirement case from `paramiko.prefetch` mechanism. Paramiko internally calls: `resp = self.file_table[handle].stat()` where self.file_table[handle] return instance of mockssh.sftp.SFTPHandle class.