### PR TITLE
use selectors instead of select.select

### DIFF
--- a/mockssh/server.py
+++ b/mockssh/server.py
@@ -135,9 +135,9 @@ class Server(object):
     def _run(self):
         sock = self._socket
         selector = selectors.DefaultSelector()
+        selector.register(sock, selectors.EVENT_READ)
         while sock.fileno() > 0:
             self.log.debug("Waiting for incoming connections ...")
-            selector.register(sock, selectors.EVENT_READ)
             events = selector.select(timeout=1.0)
             if events:
                 try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 paramiko
+selectors2; python_version < '3.4'


### PR DESCRIPTION
Hi! On [DVC](https://github.com/iterative/dvc), we were having random test failures. On investigating, we found out that we were going over 1024 opened file descriptors which `select` fails to work with and had issue on our implementation, as well as the mock server.

So, this PR uses higher level [`selectors`](https://docs.python.org/3/library/selectors.html) which uses `*poll/kqueue` on supported platforms and fallbacks to select. On Windows, sadly there's no alternative and we are stuck with the issue.

I have added [`selectors2`](https://pypi.org/project/selectors2/) for <3.4  (`selectors` was introduced in 3.4).
It'd be great if we could merge this. Thanks.