### PR TITLE
Remove deprecations+tox update

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v1

--- a/mockssh/server.py
+++ b/mockssh/server.py
@@ -49,7 +49,7 @@ class Handler(paramiko.ServerInterface):
             if channel.chanid not in self.command_queues:
                 self.command_queues[channel.chanid] = Queue()
             t = threading.Thread(target=self.handle_client, args=(channel,))
-            t.setDaemon(True)
+            t.daemon = True
             t.start()
 
     def handle_client(self, channel):
@@ -128,7 +128,7 @@ class Server(object):
         s.bind((self.host, 0))
         s.listen(5)
         self._thread = t = threading.Thread(target=self._run)
-        t.setDaemon(True)
+        t.daemon = True
         t.start()
         return self
 
@@ -149,7 +149,7 @@ class Server(object):
                 self.log.debug("... got connection %s from %s", conn, addr)
                 handler = self.handler_cls(self, (conn, addr))
                 t = threading.Thread(target=handler.run)
-                t.setDaemon(True)
+                t.daemon = True
                 t.start()
 
     def __exit__(self, *exc_info):

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,11 @@ envlist = py27, py35, py36, py37, py38, py39, py310
 
 [gh-actions]
 python =
-  2.7: py27
-  3.5: py35
-  3.6: py36
   3.7: py37
   3.8: py38
   3.9: py39
   3.10: py310
+  3.11: py311
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, py38, py39
+envlist = py27, py35, py36, py37, py38, py39, py310
 
 [gh-actions]
 python =
@@ -9,6 +9,7 @@ python =
   3.7: py37
   3.8: py38
   3.9: py39
+  3.10: py310
 
 [testenv]
 commands =


### PR DESCRIPTION
- Remove support for <=py3.6
- Configure github workflows and tox to include 3.10 and 3.11 in testing.
- Remove deprecation notices