### PR TITLE
Feature/types

### DIFF
--- a/mockssh/__init__.py
+++ b/mockssh/__init__.py
@@ -1,6 +1,5 @@
 from mockssh import server
 
-
 __all__ = [
     "Server"
 ]

--- a/mockssh/conftest.py
+++ b/mockssh/conftest.py
@@ -1,12 +1,11 @@
-import tempfile
 import logging
-import shutil
 import os
+import shutil
+import tempfile
 
 from pytest import fixture
 
 from mockssh import Server
-
 
 __all__ = [
     "server",

--- a/mockssh/conftest.py
+++ b/mockssh/conftest.py
@@ -6,6 +6,9 @@ import tempfile
 from pytest import fixture
 
 from mockssh import Server
+import mockssh.server
+from paramiko.sftp_client import SFTPClient
+from typing import Iterator
 
 __all__ = [
     "server",
@@ -16,12 +19,12 @@ SAMPLE_USER_KEY = os.path.join(os.path.dirname(__file__), "sample-user-key")
 
 
 @fixture
-def user_key_path():
+def user_key_path() -> str:
     return SAMPLE_USER_KEY
 
 
 @fixture(scope="function")
-def server():
+def server() -> Iterator[mockssh.server.Server]:
     users = {
         "sample-user": SAMPLE_USER_KEY,
     }
@@ -30,14 +33,14 @@ def server():
 
 
 @fixture
-def sftp_client(server):
+def sftp_client(server: mockssh.server.Server) -> Iterator[SFTPClient]:
     uid = tuple(server.users)[0]
     c = server.client(uid)
     yield c.open_sftp()
 
 
 @fixture
-def tmp_dir():
+def tmp_dir() -> Iterator[str]:
     if hasattr(tempfile, "TemporaryDirectory"):
         # python 3
         with tempfile.TemporaryDirectory() as td:

--- a/mockssh/server.py
+++ b/mockssh/server.py
@@ -1,19 +1,16 @@
 import errno
 import logging
 import os
+import selectors
 import socket
 import subprocess
 import threading
-
-from mockssh.streaming import StreamTransfer
-
 from queue import Queue
-
-import selectors
 
 import paramiko
 
 from mockssh import sftp
+from mockssh.streaming import StreamTransfer
 
 __all__ = [
     "Server",

--- a/mockssh/server.py
+++ b/mockssh/server.py
@@ -7,15 +7,9 @@ import threading
 
 from mockssh.streaming import StreamTransfer
 
-try:
-    from queue import Queue
-except ImportError:  # Python 2.7
-    from Queue import Queue
+from queue import Queue
 
-try:
-    import selectors
-except ImportError:  # Python 2.7
-    import selectors2 as selectors
+import selectors
 
 import paramiko
 

--- a/mockssh/sftp.py
+++ b/mockssh/sftp.py
@@ -3,6 +3,7 @@ import os
 from errno import EACCES, EDQUOT, ENOENT, ENOTDIR, EPERM, EROFS
 
 import paramiko
+from typing import Callable
 
 __all__ = [
     "SFTPServer",
@@ -33,7 +34,7 @@ class SFTPHandle(paramiko.SFTPHandle):
 LOG = logging.getLogger(__name__)
 
 
-def returns_sftp_error(func):
+def returns_sftp_error(func: Callable) -> Callable:
 
     def wrapped(*args, **kwargs):
         try:

--- a/mockssh/sftp.py
+++ b/mockssh/sftp.py
@@ -1,10 +1,8 @@
 import logging
 import os
-
-from errno import EACCES, EDQUOT, EPERM, EROFS, ENOENT, ENOTDIR
+from errno import EACCES, EDQUOT, ENOENT, ENOTDIR, EPERM, EROFS
 
 import paramiko
-
 
 __all__ = [
     "SFTPServer",

--- a/mockssh/streaming.py
+++ b/mockssh/streaming.py
@@ -1,7 +1,4 @@
-try:
-    import selectors
-except ImportError:  # Python 2.7
-    import selectors2 as selectors
+import selectors
 
 
 class Stream:

--- a/mockssh/test_server.py
+++ b/mockssh/test_server.py
@@ -11,7 +11,7 @@ from _pytest.monkeypatch import MonkeyPatch
 from mockssh.server import Server
 
 
-def test_ssh_session(server: Server) -> None:
+def test_ssh_session(server: Server):
     for uid in server.users:
         with server.client(uid) as c:
             _, stdout, _ = c.exec_command("ls /")
@@ -23,7 +23,7 @@ def test_ssh_session(server: Server) -> None:
                     platform.node())
 
 
-def test_ssh_failed_commands(server: Server) -> None:
+def test_ssh_failed_commands(server: Server):
     for uid in server.users:
         with server.client(uid) as c:
             _, _, stderr = c.exec_command("rm /")
@@ -32,27 +32,27 @@ def test_ssh_failed_commands(server: Server) -> None:
                     stderr.startswith("rm: /: is a directory"))
 
 
-def test_multiple_connections1(server: Server) -> None:
+def test_multiple_connections1(server: Server):
     _test_multiple_connections(server)
 
 
-def test_multiple_connections2(server: Server) -> None:
+def test_multiple_connections2(server: Server):
     _test_multiple_connections(server)
 
 
-def test_multiple_connections3(server: Server) -> None:
+def test_multiple_connections3(server: Server):
     _test_multiple_connections(server)
 
 
-def test_multiple_connections4(server: Server) -> None:
+def test_multiple_connections4(server: Server):
     _test_multiple_connections(server)
 
 
-def test_multiple_connections5(server: Server) -> None:
+def test_multiple_connections5(server: Server):
     _test_multiple_connections(server)
 
 
-def _test_multiple_connections(server: Server) -> None:
+def _test_multiple_connections(server: Server):
     # This test will deadlock without ea1e0f80aac7253d2d346732eefd204c6627f4c8
     fd, pkey_path = tempfile.mkstemp()
     user, private_key = list(server._users.items())[0]
@@ -64,13 +64,13 @@ def _test_multiple_connections(server: Server) -> None:
     assert p.decode('utf-8').strip() == 'hello'
 
 
-def test_invalid_user(server: Server) -> None:
+def test_invalid_user(server: Server):
     with raises(KeyError) as exc:
         server.client("unknown-user")
     assert exc.value.args[0] == "unknown-user"
 
 
-def test_add_user(server: Server, user_key_path: str) -> None:
+def test_add_user(server: Server, user_key_path: str):
     with raises(KeyError):
         server.client("new-user")
 
@@ -80,7 +80,7 @@ def test_add_user(server: Server, user_key_path: str) -> None:
         assert codecs.decode(stdout.read().strip(), "utf8") == "42"
 
 
-def test_overwrite_handler(server: Server, monkeypatch: MonkeyPatch) -> None:
+def test_overwrite_handler(server: Server, monkeypatch: MonkeyPatch):
     class MyHandler(mockssh.server.Handler):
         def check_auth_password(self, username, password):
             if username == "foo" and password == "bar":

--- a/mockssh/test_server.py
+++ b/mockssh/test_server.py
@@ -7,9 +7,11 @@ import paramiko
 from pytest import raises
 
 import mockssh
+from _pytest.monkeypatch import MonkeyPatch
+from mockssh.server import Server
 
 
-def test_ssh_session(server):
+def test_ssh_session(server: Server) -> None:
     for uid in server.users:
         with server.client(uid) as c:
             _, stdout, _ = c.exec_command("ls /")
@@ -21,7 +23,7 @@ def test_ssh_session(server):
                     platform.node())
 
 
-def test_ssh_failed_commands(server):
+def test_ssh_failed_commands(server: Server) -> None:
     for uid in server.users:
         with server.client(uid) as c:
             _, _, stderr = c.exec_command("rm /")
@@ -30,27 +32,27 @@ def test_ssh_failed_commands(server):
                     stderr.startswith("rm: /: is a directory"))
 
 
-def test_multiple_connections1(server):
+def test_multiple_connections1(server: Server) -> None:
     _test_multiple_connections(server)
 
 
-def test_multiple_connections2(server):
+def test_multiple_connections2(server: Server) -> None:
     _test_multiple_connections(server)
 
 
-def test_multiple_connections3(server):
+def test_multiple_connections3(server: Server) -> None:
     _test_multiple_connections(server)
 
 
-def test_multiple_connections4(server):
+def test_multiple_connections4(server: Server) -> None:
     _test_multiple_connections(server)
 
 
-def test_multiple_connections5(server):
+def test_multiple_connections5(server: Server) -> None:
     _test_multiple_connections(server)
 
 
-def _test_multiple_connections(server):
+def _test_multiple_connections(server: Server) -> None:
     # This test will deadlock without ea1e0f80aac7253d2d346732eefd204c6627f4c8
     fd, pkey_path = tempfile.mkstemp()
     user, private_key = list(server._users.items())[0]
@@ -62,13 +64,13 @@ def _test_multiple_connections(server):
     assert p.decode('utf-8').strip() == 'hello'
 
 
-def test_invalid_user(server):
+def test_invalid_user(server: Server) -> None:
     with raises(KeyError) as exc:
         server.client("unknown-user")
     assert exc.value.args[0] == "unknown-user"
 
 
-def test_add_user(server, user_key_path):
+def test_add_user(server: Server, user_key_path: str) -> None:
     with raises(KeyError):
         server.client("new-user")
 
@@ -78,7 +80,7 @@ def test_add_user(server, user_key_path):
         assert codecs.decode(stdout.read().strip(), "utf8") == "42"
 
 
-def test_overwrite_handler(server, monkeypatch):
+def test_overwrite_handler(server: Server, monkeypatch: MonkeyPatch) -> None:
     class MyHandler(mockssh.server.Handler):
         def check_auth_password(self, username, password):
             if username == "foo" and password == "bar":

--- a/mockssh/test_sftp.py
+++ b/mockssh/test_sftp.py
@@ -12,19 +12,19 @@ def files_equal(fname1: str, fname2: str) -> bool:
                 return True
 
 
-def test_put(sftp_client: SFTPClient, tmp_dir: str) -> None:
+def test_put(sftp_client: SFTPClient, tmp_dir: str):
     target_fname = os.path.join(tmp_dir, "foo")
     sftp_client.put(__file__, target_fname, confirm=True)
     assert files_equal(target_fname, __file__)
 
 
-def test_get(sftp_client: SFTPClient, tmp_dir: str) -> None:
+def test_get(sftp_client: SFTPClient, tmp_dir: str):
     target_fname = os.path.join(tmp_dir, "foo")
     sftp_client.get(__file__, target_fname)
     assert files_equal(target_fname, __file__)
 
 
-def test_symlink(sftp_client: SFTPClient, tmp_dir: str) -> None:
+def test_symlink(sftp_client: SFTPClient, tmp_dir: str):
     foo = os.path.join(tmp_dir, "foo")
     bar = os.path.join(tmp_dir, "bar")
 
@@ -33,7 +33,7 @@ def test_symlink(sftp_client: SFTPClient, tmp_dir: str) -> None:
     assert os.path.islink(bar)
 
 
-def test_lstat(sftp_client: SFTPClient, tmp_dir: str) -> None:
+def test_lstat(sftp_client: SFTPClient, tmp_dir: str):
     foo = os.path.join(tmp_dir, "foo")
     bar = os.path.join(tmp_dir, "bar")
 
@@ -45,7 +45,7 @@ def test_lstat(sftp_client: SFTPClient, tmp_dir: str) -> None:
     assert stat.st_size != lstat.st_size
 
 
-def test_listdir(sftp_client: SFTPClient, tmp_dir: str) -> None:
+def test_listdir(sftp_client: SFTPClient, tmp_dir: str):
     open(os.path.join(tmp_dir, "foo"), "w").write("foo")
     open(os.path.join(tmp_dir, "bar"), "w").write("bar")
 
@@ -56,28 +56,28 @@ def test_listdir(sftp_client: SFTPClient, tmp_dir: str) -> None:
         sftp_client.listdir("/123_no_dir")
 
 
-def test_remove(sftp_client: SFTPClient, tmp_dir: str) -> None:
+def test_remove(sftp_client: SFTPClient, tmp_dir: str):
     test_file = os.path.join(tmp_dir, "x")
     open(test_file, "w").write("X")
     sftp_client.remove(test_file)
     assert not os.listdir(tmp_dir)
 
 
-def test_unlink(sftp_client: SFTPClient, tmp_dir: str) -> None:
+def test_unlink(sftp_client: SFTPClient, tmp_dir: str):
     test_file = os.path.join(tmp_dir, "x")
     open(test_file, "w").write("X")
     sftp_client.unlink(test_file)
     assert not os.listdir(tmp_dir)
 
 
-def test_mkdir(sftp_client: SFTPClient, tmp_dir: str) -> None:
+def test_mkdir(sftp_client: SFTPClient, tmp_dir: str):
     target_dir = os.path.join(tmp_dir, "foo")
     sftp_client.mkdir(target_dir)
     assert os.path.exists(target_dir)
     assert os.path.isdir(target_dir)
 
 
-def test_rmdir(sftp_client: SFTPClient, tmp_dir: str) -> None:
+def test_rmdir(sftp_client: SFTPClient, tmp_dir: str):
     target_dir = os.path.join(tmp_dir, "foo")
     os.makedirs(target_dir)
     sftp_client.rmdir(target_dir)
@@ -85,7 +85,7 @@ def test_rmdir(sftp_client: SFTPClient, tmp_dir: str) -> None:
     assert not os.path.isdir(target_dir)
 
 
-def test_chmod(sftp_client: SFTPClient, tmp_dir: str) -> None:
+def test_chmod(sftp_client: SFTPClient, tmp_dir: str):
     test_file = os.path.join(tmp_dir, "foo")
     open(test_file, "w").write("X")
     sftp_client.chmod(test_file, 0o600)
@@ -94,7 +94,7 @@ def test_chmod(sftp_client: SFTPClient, tmp_dir: str) -> None:
     assert st.st_mode & check_bits == 0o600
 
 
-def test_chown(sftp_client: SFTPClient, tmp_dir: str) -> None:
+def test_chown(sftp_client: SFTPClient, tmp_dir: str):
     test_file = os.path.join(tmp_dir, "foo")
     open(test_file, "w").write("X")
     # test process probably can't change file uids
@@ -102,7 +102,7 @@ def test_chown(sftp_client: SFTPClient, tmp_dir: str) -> None:
     sftp_client.chown(test_file, os.getuid(), os.getgid())
 
 
-def test_handle_stat(sftp_client: SFTPClient, tmp_dir: str) -> None:
+def test_handle_stat(sftp_client: SFTPClient, tmp_dir: str):
     test_file = os.path.join(tmp_dir, "foo")
     open(test_file, "w").write("X")
 
@@ -111,7 +111,7 @@ def test_handle_stat(sftp_client: SFTPClient, tmp_dir: str) -> None:
     handle.stat()
 
 
-def test_rename(sftp_client: SFTPClient, tmp_dir: str) -> None:
+def test_rename(sftp_client: SFTPClient, tmp_dir: str):
     test_file = os.path.join(tmp_dir, "foo")
     open(test_file, "w").write("X")
     renamed_test_file = os.path.join(tmp_dir, "bar")

--- a/mockssh/test_sftp.py
+++ b/mockssh/test_sftp.py
@@ -2,28 +2,29 @@ import os
 import stat
 
 from pytest import fixture, raises
+from paramiko.sftp_client import SFTPClient
 
 
-def files_equal(fname1, fname2):
+def files_equal(fname1: str, fname2: str) -> bool:
     if os.stat(fname1).st_size == os.stat(fname2).st_size:
         with open(fname1, "rb") as f1, open(fname2, "rb") as f2:
             if f1.read() == f2.read():
                 return True
 
 
-def test_put(sftp_client, tmp_dir):
+def test_put(sftp_client: SFTPClient, tmp_dir: str) -> None:
     target_fname = os.path.join(tmp_dir, "foo")
     sftp_client.put(__file__, target_fname, confirm=True)
     assert files_equal(target_fname, __file__)
 
 
-def test_get(sftp_client, tmp_dir):
+def test_get(sftp_client: SFTPClient, tmp_dir: str) -> None:
     target_fname = os.path.join(tmp_dir, "foo")
     sftp_client.get(__file__, target_fname)
     assert files_equal(target_fname, __file__)
 
 
-def test_symlink(sftp_client, tmp_dir):
+def test_symlink(sftp_client: SFTPClient, tmp_dir: str) -> None:
     foo = os.path.join(tmp_dir, "foo")
     bar = os.path.join(tmp_dir, "bar")
 
@@ -32,7 +33,7 @@ def test_symlink(sftp_client, tmp_dir):
     assert os.path.islink(bar)
 
 
-def test_lstat(sftp_client, tmp_dir):
+def test_lstat(sftp_client: SFTPClient, tmp_dir: str) -> None:
     foo = os.path.join(tmp_dir, "foo")
     bar = os.path.join(tmp_dir, "bar")
 
@@ -44,7 +45,7 @@ def test_lstat(sftp_client, tmp_dir):
     assert stat.st_size != lstat.st_size
 
 
-def test_listdir(sftp_client, tmp_dir):
+def test_listdir(sftp_client: SFTPClient, tmp_dir: str) -> None:
     open(os.path.join(tmp_dir, "foo"), "w").write("foo")
     open(os.path.join(tmp_dir, "bar"), "w").write("bar")
 
@@ -55,28 +56,28 @@ def test_listdir(sftp_client, tmp_dir):
         sftp_client.listdir("/123_no_dir")
 
 
-def test_remove(sftp_client, tmp_dir):
+def test_remove(sftp_client: SFTPClient, tmp_dir: str) -> None:
     test_file = os.path.join(tmp_dir, "x")
     open(test_file, "w").write("X")
     sftp_client.remove(test_file)
     assert not os.listdir(tmp_dir)
 
 
-def test_unlink(sftp_client, tmp_dir):
+def test_unlink(sftp_client: SFTPClient, tmp_dir: str) -> None:
     test_file = os.path.join(tmp_dir, "x")
     open(test_file, "w").write("X")
     sftp_client.unlink(test_file)
     assert not os.listdir(tmp_dir)
 
 
-def test_mkdir(sftp_client, tmp_dir):
+def test_mkdir(sftp_client: SFTPClient, tmp_dir: str) -> None:
     target_dir = os.path.join(tmp_dir, "foo")
     sftp_client.mkdir(target_dir)
     assert os.path.exists(target_dir)
     assert os.path.isdir(target_dir)
 
 
-def test_rmdir(sftp_client, tmp_dir):
+def test_rmdir(sftp_client: SFTPClient, tmp_dir: str) -> None:
     target_dir = os.path.join(tmp_dir, "foo")
     os.makedirs(target_dir)
     sftp_client.rmdir(target_dir)
@@ -84,7 +85,7 @@ def test_rmdir(sftp_client, tmp_dir):
     assert not os.path.isdir(target_dir)
 
 
-def test_chmod(sftp_client, tmp_dir):
+def test_chmod(sftp_client: SFTPClient, tmp_dir: str) -> None:
     test_file = os.path.join(tmp_dir, "foo")
     open(test_file, "w").write("X")
     sftp_client.chmod(test_file, 0o600)
@@ -93,7 +94,7 @@ def test_chmod(sftp_client, tmp_dir):
     assert st.st_mode & check_bits == 0o600
 
 
-def test_chown(sftp_client, tmp_dir):
+def test_chown(sftp_client: SFTPClient, tmp_dir: str) -> None:
     test_file = os.path.join(tmp_dir, "foo")
     open(test_file, "w").write("X")
     # test process probably can't change file uids
@@ -101,7 +102,7 @@ def test_chown(sftp_client, tmp_dir):
     sftp_client.chown(test_file, os.getuid(), os.getgid())
 
 
-def test_handle_stat(sftp_client, tmp_dir):
+def test_handle_stat(sftp_client: SFTPClient, tmp_dir: str) -> None:
     test_file = os.path.join(tmp_dir, "foo")
     open(test_file, "w").write("X")
 
@@ -110,7 +111,7 @@ def test_handle_stat(sftp_client, tmp_dir):
     handle.stat()
 
 
-def test_rename(sftp_client, tmp_dir):
+def test_rename(sftp_client: SFTPClient, tmp_dir: str) -> None:
     test_file = os.path.join(tmp_dir, "foo")
     open(test_file, "w").write("X")
     renamed_test_file = os.path.join(tmp_dir, "bar")

--- a/mockssh/test_streaming.py
+++ b/mockssh/test_streaming.py
@@ -1,17 +1,18 @@
 import random
 import string
+from mockssh.server import Server
 
 
-def first_user(server):
+def first_user(server: Server) -> str:
     for uid in server.users:
         return uid
 
 
-def random_string():
+def random_string() -> str:
     return "".join(random.choice(string.ascii_letters) for _ in range(20))
 
 
-def streaming_test(server, command, tested_fd, number_of_inputs=1):
+def streaming_test(server: Server, command: str, tested_fd: int, number_of_inputs: int=1) -> None:
     with server.client(first_user(server)) as c:
         fds = stdin, stdout, stderr = c.exec_command(command)
         for i in range(number_of_inputs):
@@ -22,13 +23,13 @@ def streaming_test(server, command, tested_fd, number_of_inputs=1):
             assert channel_output == channel_input
 
 
-def test_stdin_to_stdout(server):
+def test_stdin_to_stdout(server: Server) -> None:
     return streaming_test(server, "cat", 1)
 
 
-def test_stdin_to_stderr(server):
+def test_stdin_to_stderr(server: Server) -> None:
     streaming_test(server, "cat 1>&2", 2)
 
 
-def test_streaming_output(server):
+def test_streaming_output(server: Server) -> None:
     streaming_test(server, "cat", 1, 100)

--- a/mockssh/test_streaming.py
+++ b/mockssh/test_streaming.py
@@ -12,7 +12,7 @@ def random_string() -> str:
     return "".join(random.choice(string.ascii_letters) for _ in range(20))
 
 
-def streaming_test(server: Server, command: str, tested_fd: int, number_of_inputs: int=1) -> None:
+def streaming_test(server: Server, command: str, tested_fd: int, number_of_inputs: int=1):
     with server.client(first_user(server)) as c:
         fds = stdin, stdout, stderr = c.exec_command(command)
         for i in range(number_of_inputs):
@@ -23,13 +23,13 @@ def streaming_test(server: Server, command: str, tested_fd: int, number_of_input
             assert channel_output == channel_input
 
 
-def test_stdin_to_stdout(server: Server) -> None:
+def test_stdin_to_stdout(server: Server):
     return streaming_test(server, "cat", 1)
 
 
-def test_stdin_to_stderr(server: Server) -> None:
+def test_stdin_to_stderr(server: Server):
     streaming_test(server, "cat 1>&2", 2)
 
 
-def test_streaming_output(server: Server) -> None:
+def test_streaming_output(server: Server):
     streaming_test(server, "cat", 1, 100)


### PR DESCRIPTION
Applies the following changes

1. Removes python2.7 imports
2. Applies isort with default rules
3. Used [Monkeytype](https://monkeytype.readthedocs.io/en/latest/) and `monkeytype run ../../bin/pytest mockssh` command to apply typing annotations.