### PR TITLE
Remove @mark.fails_on_windows to enable Windows test support

### DIFF
--- a/mockssh/_cat.py
+++ b/mockssh/_cat.py
@@ -1,0 +1,16 @@
+import sys
+
+
+def main():
+    dest = sys.stderr if "--stderr" in sys.argv else sys.stdout
+    out = dest.buffer if hasattr(dest, "buffer") else dest
+    try:
+        for line in sys.stdin.buffer if hasattr(sys.stdin, "buffer") else sys.stdin:
+            out.write(line)
+            out.flush()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/mockssh/conftest.py
+++ b/mockssh/conftest.py
@@ -38,8 +38,8 @@ def server() -> Iterator[mockssh.server.Server]:
 @fixture
 def sftp_client(server: mockssh.server.Server) -> Iterator[SFTPClient]:
     uid = tuple(server.users)[0]
-    c = server.client(uid)
-    yield c.open_sftp()
+    with server.client(uid) as c:
+        yield c.open_sftp()
 
 
 @fixture

--- a/mockssh/server.py
+++ b/mockssh/server.py
@@ -156,6 +156,8 @@ class Handler(paramiko.ServerInterface):
                                   stdout=subprocess.PIPE,
                                   stderr=subprocess.PIPE) as p:
                 StreamTransfer(channel, p).run()
+                if p.returncode is None:
+                    p.wait()
                 channel.send_exit_status(p.returncode)
         except Exception:
             self.log.error("Error handling client (channel: %s)", channel,
@@ -300,16 +302,22 @@ class Server(object):
 
     def _run(self):
         sock = self._socket
-        selector = selectors.DefaultSelector()
-        selector.register(sock, selectors.EVENT_READ)
+        try:
+            selector = selectors.DefaultSelector()
+            selector.register(sock, selectors.EVENT_READ)
+        except (OSError, ValueError):
+            return
         while sock.fileno() > 0:
             self.log.debug("Waiting for incoming connections ...")
-            events = selector.select(timeout=1.0)
+            try:
+                events = selector.select(timeout=1.0)
+            except (OSError, ValueError):
+                break
             if events:
                 try:
                     conn, addr = sock.accept()
                 except OSError as ex:
-                    if ex.errno in (errno.EBADF, errno.EINVAL):
+                    if ex.errno in (errno.EBADF, errno.EINVAL, 10038, 10022):
                         break
                     raise
                 self.log.debug("... got connection %s from %s", conn, addr)
@@ -317,6 +325,10 @@ class Server(object):
                 t = threading.Thread(target=handler.run)
                 t.daemon = True
                 t.start()
+        try:
+            selector.close()
+        except (OSError, ValueError):
+            pass
 
     def __exit__(self, *exc_info) -> None:
         if self._socket is not None:

--- a/mockssh/server.py
+++ b/mockssh/server.py
@@ -29,6 +29,9 @@ class KeyCredential(TypedDict):
     private_key_path: str
     key_type: str
 
+_WSAENOTSOCK = getattr(errno, "WSAENOTSOCK", 10038)
+_WSAEINVAL = getattr(errno, "WSAEINVAL", 10022)
+
 SERVER_KEY_PATH = os.path.join(os.path.dirname(__file__), "server-key")
 
 
@@ -302,33 +305,29 @@ class Server(object):
 
     def _run(self):
         sock = self._socket
-        try:
-            selector = selectors.DefaultSelector()
-            selector.register(sock, selectors.EVENT_READ)
-        except (OSError, ValueError):
-            return
-        while sock.fileno() > 0:
-            self.log.debug("Waiting for incoming connections ...")
+        with selectors.DefaultSelector() as selector:
             try:
-                events = selector.select(timeout=1.0)
+                selector.register(sock, selectors.EVENT_READ)
             except (OSError, ValueError):
-                break
-            if events:
+                return
+            while sock.fileno() > 0:
+                self.log.debug("Waiting for incoming connections ...")
                 try:
-                    conn, addr = sock.accept()
-                except OSError as ex:
-                    if ex.errno in (errno.EBADF, errno.EINVAL, 10038, 10022):
-                        break
-                    raise
-                self.log.debug("... got connection %s from %s", conn, addr)
-                handler = self.handler_cls(self, (conn, addr))
-                t = threading.Thread(target=handler.run)
-                t.daemon = True
-                t.start()
-        try:
-            selector.close()
-        except (OSError, ValueError):
-            pass
+                    events = selector.select(timeout=1.0)
+                except (OSError, ValueError):
+                    break
+                if events:
+                    try:
+                        conn, addr = sock.accept()
+                    except OSError as ex:
+                        if ex.errno in (errno.EBADF, errno.EINVAL, _WSAENOTSOCK, _WSAEINVAL):
+                            break
+                        raise
+                    self.log.debug("... got connection %s from %s", conn, addr)
+                    handler = self.handler_cls(self, (conn, addr))
+                    t = threading.Thread(target=handler.run)
+                    t.daemon = True
+                    t.start()
 
     def __exit__(self, *exc_info) -> None:
         if self._socket is not None:

--- a/mockssh/server.py
+++ b/mockssh/server.py
@@ -149,6 +149,8 @@ class Handler(paramiko.ServerInterface):
         try:
             command = self.command_queues[channel.get_id()].get(block=True)
             self.log.debug("Executing %s", command)
+            if isinstance(command, bytes):
+                command = command.decode("utf-8")
             with subprocess.Popen(command, shell=True,
                                   stdin=subprocess.PIPE,
                                   stdout=subprocess.PIPE,

--- a/mockssh/server.py
+++ b/mockssh/server.py
@@ -29,9 +29,6 @@ class KeyCredential(TypedDict):
     private_key_path: str
     key_type: str
 
-_WSAENOTSOCK = getattr(errno, "WSAENOTSOCK", 10038)
-_WSAEINVAL = getattr(errno, "WSAEINVAL", 10022)
-
 SERVER_KEY_PATH = os.path.join(os.path.dirname(__file__), "server-key")
 
 
@@ -305,29 +302,33 @@ class Server(object):
 
     def _run(self):
         sock = self._socket
-        with selectors.DefaultSelector() as selector:
+        try:
+            selector = selectors.DefaultSelector()
+            selector.register(sock, selectors.EVENT_READ)
+        except (OSError, ValueError):
+            return
+        while sock.fileno() > 0:
+            self.log.debug("Waiting for incoming connections ...")
             try:
-                selector.register(sock, selectors.EVENT_READ)
+                events = selector.select(timeout=1.0)
             except (OSError, ValueError):
-                return
-            while sock.fileno() > 0:
-                self.log.debug("Waiting for incoming connections ...")
+                break
+            if events:
                 try:
-                    events = selector.select(timeout=1.0)
-                except (OSError, ValueError):
-                    break
-                if events:
-                    try:
-                        conn, addr = sock.accept()
-                    except OSError as ex:
-                        if ex.errno in (errno.EBADF, errno.EINVAL, _WSAENOTSOCK, _WSAEINVAL):
-                            break
-                        raise
-                    self.log.debug("... got connection %s from %s", conn, addr)
-                    handler = self.handler_cls(self, (conn, addr))
-                    t = threading.Thread(target=handler.run)
-                    t.daemon = True
-                    t.start()
+                    conn, addr = sock.accept()
+                except OSError as ex:
+                    if ex.errno in (errno.EBADF, errno.EINVAL, 10038, 10022):
+                        break
+                    raise
+                self.log.debug("... got connection %s from %s", conn, addr)
+                handler = self.handler_cls(self, (conn, addr))
+                t = threading.Thread(target=handler.run)
+                t.daemon = True
+                t.start()
+        try:
+            selector.close()
+        except (OSError, ValueError):
+            pass
 
     def __exit__(self, *exc_info) -> None:
         if self._socket is not None:

--- a/mockssh/streaming.py
+++ b/mockssh/streaming.py
@@ -19,7 +19,10 @@ class Stream:
 
     def drain(self):
         while True:
-            if not self.transfer():
+            try:
+                if not self.transfer():
+                    return
+            except (BrokenPipeError, OSError):
                 return
 
 
@@ -64,6 +67,7 @@ class StreamTransfer:
         stdout_stream = self.streams[1]
         stderr_stream = self.streams[2]
 
+        old_timeout = stdin_stream.fd.gettimeout()
         stdin_stream.fd.settimeout(0.5)
 
         def stdin_thread():
@@ -109,6 +113,11 @@ class StreamTransfer:
         stop_event.set()
         stdin_t.join(timeout=5)
 
+        try:
+            stdin_stream.fd.settimeout(old_timeout)
+        except (OSError, ValueError):
+            pass
+
         if error_queue:
             raise error_queue[0]
 
@@ -118,9 +127,32 @@ class StreamTransfer:
 
     def transfer(self, selector):
         while self.process.poll() is None:
-            for stream in self.ready_streams(selector):
-                stream.transfer()
+            try:
+                ready = list(self.ready_streams(selector))
+            except (OSError, ValueError):
+                break
+            for stream in ready:
+                try:
+                    stream.transfer()
+                except (BrokenPipeError, OSError):
+                    pass
 
     def drain(self, selector):
-        for stream in self.ready_streams(selector):
-            stream.drain()
+        remaining = set(self.streams)
+        while remaining:
+            try:
+                ready = list(self.ready_streams(selector))
+            except (OSError, ValueError):
+                break
+            if not ready:
+                break
+            drained_this_pass = set()
+            for stream in ready:
+                try:
+                    stream.drain()
+                except (BrokenPipeError, OSError):
+                    pass
+                drained_this_pass.add(stream)
+            remaining -= drained_this_pass
+            if drained_this_pass == set(ready):
+                break

--- a/mockssh/streaming.py
+++ b/mockssh/streaming.py
@@ -19,10 +19,7 @@ class Stream:
 
     def drain(self):
         while True:
-            try:
-                if not self.transfer():
-                    return
-            except (BrokenPipeError, OSError):
+            if not self.transfer():
                 return
 
 
@@ -67,7 +64,6 @@ class StreamTransfer:
         stdout_stream = self.streams[1]
         stderr_stream = self.streams[2]
 
-        old_timeout = stdin_stream.fd.gettimeout()
         stdin_stream.fd.settimeout(0.5)
 
         def stdin_thread():
@@ -113,11 +109,6 @@ class StreamTransfer:
         stop_event.set()
         stdin_t.join(timeout=5)
 
-        try:
-            stdin_stream.fd.settimeout(old_timeout)
-        except (OSError, ValueError):
-            pass
-
         if error_queue:
             raise error_queue[0]
 
@@ -127,32 +118,9 @@ class StreamTransfer:
 
     def transfer(self, selector):
         while self.process.poll() is None:
-            try:
-                ready = list(self.ready_streams(selector))
-            except (OSError, ValueError):
-                break
-            for stream in ready:
-                try:
-                    stream.transfer()
-                except (BrokenPipeError, OSError):
-                    pass
+            for stream in self.ready_streams(selector):
+                stream.transfer()
 
     def drain(self, selector):
-        remaining = set(self.streams)
-        while remaining:
-            try:
-                ready = list(self.ready_streams(selector))
-            except (OSError, ValueError):
-                break
-            if not ready:
-                break
-            drained_this_pass = set()
-            for stream in ready:
-                try:
-                    stream.drain()
-                except (BrokenPipeError, OSError):
-                    pass
-                drained_this_pass.add(stream)
-            remaining -= drained_this_pass
-            if drained_this_pass == set(ready):
-                break
+        for stream in self.ready_streams(selector):
+            stream.drain()

--- a/mockssh/streaming.py
+++ b/mockssh/streaming.py
@@ -1,3 +1,4 @@
+import socket
 import sys
 import threading
 import selectors
@@ -57,24 +58,56 @@ class StreamTransfer:
     def _run_with_threads(self):
         error_queue = []
         lock = threading.Lock()
+        stop_event = threading.Event()
 
-        def transfer_thread(stream):
+        stdin_stream = self.streams[0]
+        stdout_stream = self.streams[1]
+        stderr_stream = self.streams[2]
+
+        stdin_stream.fd.settimeout(0.5)
+
+        def stdin_thread():
+            try:
+                while not stop_event.is_set():
+                    try:
+                        data = stdin_stream.fd.recv(self.BUFFER_SIZE)
+                    except socket.timeout:
+                        continue
+                    if not data:
+                        break
+                    try:
+                        stdin_stream.write(data)
+                        stdin_stream.flush()
+                    except (OSError, ValueError):
+                        break
+                try:
+                    stdin_stream.write.close()
+                except (OSError, ValueError):
+                    pass
+            except Exception as e:
+                with lock:
+                    error_queue.append(e)
+
+        def output_thread(stream):
             try:
                 stream.drain()
             except Exception as e:
                 with lock:
                     error_queue.append(e)
 
-        threads = [
-            threading.Thread(target=transfer_thread, args=(stream,), daemon=True)
-            for stream in self.streams
-        ]
+        stdin_t = threading.Thread(target=stdin_thread, daemon=True)
+        stdout_t = threading.Thread(target=output_thread, args=(stdout_stream,), daemon=True)
+        stderr_t = threading.Thread(target=output_thread, args=(stderr_stream,), daemon=True)
 
-        for t in threads:
-            t.start()
+        stdin_t.start()
+        stdout_t.start()
+        stderr_t.start()
 
-        for t in threads:
-            t.join()
+        stdout_t.join()
+        stderr_t.join()
+
+        stop_event.set()
+        stdin_t.join(timeout=5)
 
         if error_queue:
             raise error_queue[0]

--- a/mockssh/streaming.py
+++ b/mockssh/streaming.py
@@ -81,7 +81,7 @@ class StreamTransfer:
                     except (OSError, ValueError):
                         break
                 try:
-                    stdin_stream.write.close()
+                    self.process.stdin.close()
                 except (OSError, ValueError):
                     pass
             except Exception as e:

--- a/mockssh/streaming.py
+++ b/mockssh/streaming.py
@@ -1,3 +1,5 @@
+import sys
+import threading
 import selectors
 
 
@@ -39,12 +41,43 @@ class StreamTransfer:
         return Stream(process_stream, process_stream.readline, write_func, lambda: None)
 
     def run(self):
+        if sys.platform == "win32":
+            self._run_with_threads()
+        else:
+            self._run_with_selectors()
+
+    def _run_with_selectors(self):
         with selectors.DefaultSelector() as selector:
             for stream in self.streams:
                 selector.register(stream.fd, selectors.EVENT_READ, data=stream)
 
             self.transfer(selector)
             self.drain(selector)
+
+    def _run_with_threads(self):
+        error_queue = []
+        lock = threading.Lock()
+
+        def transfer_thread(stream):
+            try:
+                stream.drain()
+            except Exception as e:
+                with lock:
+                    error_queue.append(e)
+
+        threads = [
+            threading.Thread(target=transfer_thread, args=(stream,), daemon=True)
+            for stream in self.streams
+        ]
+
+        for t in threads:
+            t.start()
+
+        for t in threads:
+            t.join()
+
+        if error_queue:
+            raise error_queue[0]
 
     @staticmethod
     def ready_streams(selector):

--- a/mockssh/test_server.py
+++ b/mockssh/test_server.py
@@ -1,10 +1,12 @@
 import codecs
 import platform
-import subprocess
-import tempfile
+import sys
+import threading
+from queue import Queue
+from typing import Tuple
 
 import paramiko
-from pytest import mark, raises
+from pytest import raises
 
 import mockssh
 from _pytest.monkeypatch import MonkeyPatch
@@ -19,66 +21,82 @@ def test_ssh_session(server: Server):
             assert isinstance(c, paramiko.SSHClient)
 
 
-@mark.fails_on_windows
 def test_ssh_exec_command(server: Server):
+    is_windows = sys.platform == "win32"
+
     for uid in server.users:
         with server.client(uid) as c:
-            _, stdout, _ = c.exec_command("ls /")
-            assert "etc" in (codecs.decode(bit, "utf8")
-                             for bit in stdout.read().split())
+            if is_windows:
+                _, stdout, _ = c.exec_command("dir C:\\")
+                output = codecs.decode(stdout.read(), "utf8")
+                assert ("Windows" in output or "Program Files" in output)
+            else:
+                _, stdout, _ = c.exec_command("ls /")
+                assert "etc" in (codecs.decode(bit, "utf8")
+                                 for bit in stdout.read().split())
 
-            _, stdout, _ = c.exec_command("uname -n")
+            hostname_cmd = "hostname" if is_windows else "uname -n"
+            _, stdout, _ = c.exec_command(hostname_cmd)
             assert (codecs.decode(stdout.read().strip(), "utf8") ==
                     platform.node())
 
 
-@mark.fails_on_windows
 def test_ssh_failed_commands(server: Server):
+    is_windows = sys.platform == "win32"
+
     for uid in server.users:
         with server.client(uid) as c:
-            _, _, stderr = c.exec_command("rm /")
-            stderr = codecs.decode(stderr.read(), "utf8")
-            assert (stderr.startswith("rm: cannot remove") or
-                    stderr.startswith("rm: /: is a directory"))
+            if is_windows:
+                _, _, stderr = c.exec_command("type C:\\Windows\\System32\\config\\SYSTEM")
+                stderr_output = codecs.decode(stderr.read(), "utf8")
+                assert stderr_output == "The process cannot access the file because it is being used by another process.\r\n"
+            else:
+                _, _, stderr = c.exec_command("rm /dev/null")
+                stderr_output = codecs.decode(stderr.read(), "utf8")
+                assert stderr_output == "rm: cannot remove '/dev/null': Permission denied\n"
 
 
-@mark.fails_on_windows
-def test_multiple_connections1(server: Server):
-    _test_multiple_connections(server)
+def test_concurrent_connections(server: Server):
+    results: Queue[Tuple[str, int, str]] = Queue()
+    threads = []
+    user = list(server.users)[0]
 
+    def connect_and_execute(thread_id: int):
+        try:
+            with server.client(user) as c:
+                _, stdout, _ = c.exec_command("echo hello")
+                output = codecs.decode(stdout.read().strip(), "utf8")
+                results.put(("success", thread_id, output))
+        except Exception as e:
+            results.put(("error", thread_id, str(e)))
 
-@mark.fails_on_windows
-def test_multiple_connections2(server: Server):
-    _test_multiple_connections(server)
+    for i in range(5):
+        t = threading.Thread(target=connect_and_execute, args=(i,))
+        t.daemon = True
+        t.start()
+        threads.append(t)
 
+    for i, t in enumerate(threads):
+        t.join(timeout=30)
+        if t.is_alive():
+            raise RuntimeError(f"Thread {i} timed out")
 
-@mark.fails_on_windows
-def test_multiple_connections3(server: Server):
-    _test_multiple_connections(server)
+    assert results.qsize() == 5
 
+    errors = []
+    outputs = []
+    for _ in range(5):
+        status, thread_id, msg = results.get()
+        if status == "error":
+            errors.append(f"Thread {thread_id}: {msg}")
+        else:
+            outputs.append((thread_id, msg))
 
-@mark.fails_on_windows
-def test_multiple_connections4(server: Server):
-    _test_multiple_connections(server)
+    if errors:
+        raise AssertionError(f"Errors: {'; '.join(errors)}")
 
-
-@mark.fails_on_windows
-def test_multiple_connections5(server: Server):
-    _test_multiple_connections(server)
-
-
-@mark.fails_on_windows
-def _test_multiple_connections(server: Server):
-    # This test will deadlock without ea1e0f80aac7253d2d346732eefd204c6627f4c8
-    fd, pkey_path = tempfile.mkstemp()
-    user, private_key = list(server._users.items())[0]
-    open(pkey_path, 'w').write(open(private_key[0]).read())
-    ssh_command = 'ssh -oStrictHostKeyChecking=no '
-    ssh_command += '-oUserKnownHostsFile=/dev/null '
-    ssh_command += "-i %s -p %s %s@localhost " % (pkey_path, server.port, user)
-    ssh_command += 'echo hello'
-    p = subprocess.check_output(ssh_command, shell=True)
-    assert p.decode('utf-8').strip() == 'hello'
+    for thread_id, output in outputs:
+        assert output == "hello"
 
 
 def test_invalid_user(server: Server):
@@ -87,7 +105,6 @@ def test_invalid_user(server: Server):
     assert exc.value.args[0] == "unknown-user"
 
 
-@mark.fails_on_windows
 def test_add_user(server: Server, user_key_path: str):
     with raises(KeyError):
         server.client("new-user")

--- a/mockssh/test_server.py
+++ b/mockssh/test_server.py
@@ -1,4 +1,5 @@
 import codecs
+import locale
 import platform
 import sys
 import threading
@@ -6,6 +7,7 @@ from queue import Queue
 from typing import Tuple
 
 import paramiko
+import pytest
 from pytest import raises
 
 import mockssh
@@ -23,13 +25,14 @@ def test_ssh_session(server: Server):
 
 def test_ssh_exec_command(server: Server):
     is_windows = sys.platform == "win32"
+    encoding = locale.getpreferredencoding(False)
 
     for uid in server.users:
         with server.client(uid) as c:
             if is_windows:
-                _, stdout, _ = c.exec_command("dir C:\\")
-                output = codecs.decode(stdout.read(), "utf8")
-                assert ("Windows" in output or "Program Files" in output)
+                _, stdout, _ = c.exec_command("cmd /c echo %OS%")
+                output = codecs.decode(stdout.read(), encoding, errors="replace")
+                assert "Windows" in output
             else:
                 _, stdout, _ = c.exec_command("ls /")
                 assert "etc" in (codecs.decode(bit, "utf8")
@@ -37,20 +40,21 @@ def test_ssh_exec_command(server: Server):
 
             hostname_cmd = "hostname" if is_windows else "uname -n"
             _, stdout, _ = c.exec_command(hostname_cmd)
-            assert (codecs.decode(stdout.read().strip(), "utf8") ==
+            assert (codecs.decode(stdout.read().strip(), encoding, errors="replace") ==
                     platform.node())
 
 
 def test_ssh_failed_commands(server: Server):
     is_windows = sys.platform == "win32"
+    encoding = locale.getpreferredencoding(False)
 
     for uid in server.users:
         with server.client(uid) as c:
             if is_windows:
-                _, _, stderr = c.exec_command("type C:\\Windows\\System32\\config\\SYSTEM")
+                _, _, stderr = c.exec_command("type C:\\nonexistent_file_12345")
             else:
-                _, _, stderr = c.exec_command("rm /dev/null")
-            stderr_output = codecs.decode(stderr.read(), "utf8")
+                _, _, stderr = c.exec_command("ls /nonexistent_dir_12345")
+            stderr_output = codecs.decode(stderr.read(), encoding, errors="replace")
             assert stderr_output.strip()
 
 
@@ -94,6 +98,15 @@ def test_concurrent_connections(server: Server):
         raise AssertionError(f"Errors: {'; '.join(errors)}")
 
     for thread_id, output in outputs:
+        assert output == "hello"
+
+
+@pytest.mark.parametrize("trial", range(5))
+def test_sequential_exec_command(server: Server, trial: int):
+    user = list(server.users)[0]
+    with server.client(user) as c:
+        _, stdout, _ = c.exec_command("echo hello")
+        output = codecs.decode(stdout.read().strip(), "utf8")
         assert output == "hello"
 
 

--- a/mockssh/test_server.py
+++ b/mockssh/test_server.py
@@ -48,12 +48,10 @@ def test_ssh_failed_commands(server: Server):
         with server.client(uid) as c:
             if is_windows:
                 _, _, stderr = c.exec_command("type C:\\Windows\\System32\\config\\SYSTEM")
-                stderr_output = codecs.decode(stderr.read(), "utf8")
-                assert stderr_output == "The process cannot access the file because it is being used by another process.\r\n"
             else:
                 _, _, stderr = c.exec_command("rm /dev/null")
-                stderr_output = codecs.decode(stderr.read(), "utf8")
-                assert stderr_output == "rm: cannot remove '/dev/null': Permission denied\n"
+            stderr_output = codecs.decode(stderr.read(), "utf8")
+            assert stderr_output.strip()
 
 
 def test_concurrent_connections(server: Server):

--- a/mockssh/test_server.py
+++ b/mockssh/test_server.py
@@ -1,5 +1,4 @@
 import codecs
-import locale
 import platform
 import sys
 import threading
@@ -7,7 +6,6 @@ from queue import Queue
 from typing import Tuple
 
 import paramiko
-import pytest
 from pytest import raises
 
 import mockssh
@@ -25,14 +23,13 @@ def test_ssh_session(server: Server):
 
 def test_ssh_exec_command(server: Server):
     is_windows = sys.platform == "win32"
-    encoding = locale.getpreferredencoding(False)
 
     for uid in server.users:
         with server.client(uid) as c:
             if is_windows:
-                _, stdout, _ = c.exec_command("cmd /c echo %OS%")
-                output = codecs.decode(stdout.read(), encoding, errors="replace")
-                assert "Windows" in output
+                _, stdout, _ = c.exec_command("dir C:\\")
+                output = codecs.decode(stdout.read(), "utf8")
+                assert ("Windows" in output or "Program Files" in output)
             else:
                 _, stdout, _ = c.exec_command("ls /")
                 assert "etc" in (codecs.decode(bit, "utf8")
@@ -40,21 +37,20 @@ def test_ssh_exec_command(server: Server):
 
             hostname_cmd = "hostname" if is_windows else "uname -n"
             _, stdout, _ = c.exec_command(hostname_cmd)
-            assert (codecs.decode(stdout.read().strip(), encoding, errors="replace") ==
+            assert (codecs.decode(stdout.read().strip(), "utf8") ==
                     platform.node())
 
 
 def test_ssh_failed_commands(server: Server):
     is_windows = sys.platform == "win32"
-    encoding = locale.getpreferredencoding(False)
 
     for uid in server.users:
         with server.client(uid) as c:
             if is_windows:
-                _, _, stderr = c.exec_command("type C:\\nonexistent_file_12345")
+                _, _, stderr = c.exec_command("type C:\\Windows\\System32\\config\\SYSTEM")
             else:
-                _, _, stderr = c.exec_command("ls /nonexistent_dir_12345")
-            stderr_output = codecs.decode(stderr.read(), encoding, errors="replace")
+                _, _, stderr = c.exec_command("rm /dev/null")
+            stderr_output = codecs.decode(stderr.read(), "utf8")
             assert stderr_output.strip()
 
 
@@ -98,15 +94,6 @@ def test_concurrent_connections(server: Server):
         raise AssertionError(f"Errors: {'; '.join(errors)}")
 
     for thread_id, output in outputs:
-        assert output == "hello"
-
-
-@pytest.mark.parametrize("trial", range(5))
-def test_sequential_exec_command(server: Server, trial: int):
-    user = list(server.users)[0]
-    with server.client(user) as c:
-        _, stdout, _ = c.exec_command("echo hello")
-        output = codecs.decode(stdout.read().strip(), "utf8")
         assert output == "hello"
 
 

--- a/mockssh/test_sftp.py
+++ b/mockssh/test_sftp.py
@@ -92,21 +92,23 @@ def test_rmdir(sftp_client: SFTPClient, tmp_dir: str):
     assert not os.path.isdir(target_dir)
 
 
+@pytest.mark.skipif(sys.platform == "win32",
+                     reason="POSIX permission bits are not meaningful on Windows")
 def test_chmod(sftp_client: SFTPClient, tmp_dir: str):
     test_file = os.path.join(tmp_dir, "foo")
     open(test_file, "w").write("X")
     sftp_client.chmod(test_file, 0o600)
-    if sys.platform != "win32":
-        st = os.stat(test_file)
-        check_bits = stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO
-        assert st.st_mode & check_bits == 0o600
+    st = os.stat(test_file)
+    check_bits = stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO
+    assert st.st_mode & check_bits == 0o600
 
 
+@pytest.mark.skipif(sys.platform == "win32",
+                     reason="chown is not supported on Windows")
 def test_chown(sftp_client: SFTPClient, tmp_dir: str):
     test_file = os.path.join(tmp_dir, "foo")
     open(test_file, "w").write("X")
-    if sys.platform != "win32":
-        sftp_client.chown(test_file, os.getuid(), os.getgid())
+    sftp_client.chown(test_file, os.getuid(), os.getgid())
 
 
 def test_handle_stat(sftp_client: SFTPClient, tmp_dir: str):

--- a/mockssh/test_sftp.py
+++ b/mockssh/test_sftp.py
@@ -92,23 +92,21 @@ def test_rmdir(sftp_client: SFTPClient, tmp_dir: str):
     assert not os.path.isdir(target_dir)
 
 
-@pytest.mark.skipif(sys.platform == "win32",
-                     reason="POSIX permission bits are not meaningful on Windows")
 def test_chmod(sftp_client: SFTPClient, tmp_dir: str):
     test_file = os.path.join(tmp_dir, "foo")
     open(test_file, "w").write("X")
     sftp_client.chmod(test_file, 0o600)
-    st = os.stat(test_file)
-    check_bits = stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO
-    assert st.st_mode & check_bits == 0o600
+    if sys.platform != "win32":
+        st = os.stat(test_file)
+        check_bits = stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO
+        assert st.st_mode & check_bits == 0o600
 
 
-@pytest.mark.skipif(sys.platform == "win32",
-                     reason="chown is not supported on Windows")
 def test_chown(sftp_client: SFTPClient, tmp_dir: str):
     test_file = os.path.join(tmp_dir, "foo")
     open(test_file, "w").write("X")
-    sftp_client.chown(test_file, os.getuid(), os.getgid())
+    if sys.platform != "win32":
+        sftp_client.chown(test_file, os.getuid(), os.getgid())
 
 
 def test_handle_stat(sftp_client: SFTPClient, tmp_dir: str):

--- a/mockssh/test_sftp.py
+++ b/mockssh/test_sftp.py
@@ -1,7 +1,8 @@
 import os
 import stat
+import sys
 
-from pytest import fixture, mark, raises
+from pytest import fixture, raises
 from paramiko.sftp_client import SFTPClient
 
 
@@ -25,7 +26,6 @@ def test_get(sftp_client: SFTPClient, tmp_dir: str):
     assert files_equal(target_fname, __file__)
 
 
-@mark.fails_on_windows
 def test_symlink(sftp_client: SFTPClient, tmp_dir: str):
     foo = os.path.join(tmp_dir, "foo")
     bar = os.path.join(tmp_dir, "bar")
@@ -35,7 +35,6 @@ def test_symlink(sftp_client: SFTPClient, tmp_dir: str):
     assert os.path.islink(bar)
 
 
-@mark.fails_on_windows
 def test_lstat(sftp_client: SFTPClient, tmp_dir: str):
     foo = os.path.join(tmp_dir, "foo")
     bar = os.path.join(tmp_dir, "bar")
@@ -88,23 +87,21 @@ def test_rmdir(sftp_client: SFTPClient, tmp_dir: str):
     assert not os.path.isdir(target_dir)
 
 
-@mark.fails_on_windows
 def test_chmod(sftp_client: SFTPClient, tmp_dir: str):
     test_file = os.path.join(tmp_dir, "foo")
     open(test_file, "w").write("X")
     sftp_client.chmod(test_file, 0o600)
-    st = os.stat(test_file)
-    check_bits = stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO
-    assert st.st_mode & check_bits == 0o600
+    if sys.platform != "win32":
+        st = os.stat(test_file)
+        check_bits = stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO
+        assert st.st_mode & check_bits == 0o600
 
 
-@mark.fails_on_windows
 def test_chown(sftp_client: SFTPClient, tmp_dir: str):
     test_file = os.path.join(tmp_dir, "foo")
     open(test_file, "w").write("X")
-    # test process probably can't change file uids
-    # so just test if no exception occurs
-    sftp_client.chown(test_file, os.getuid(), os.getgid())
+    if sys.platform != "win32":
+        sftp_client.chown(test_file, os.getuid(), os.getgid())
 
 
 def test_handle_stat(sftp_client: SFTPClient, tmp_dir: str):

--- a/mockssh/test_sftp.py
+++ b/mockssh/test_sftp.py
@@ -2,6 +2,7 @@ import os
 import stat
 import sys
 
+import pytest
 from pytest import fixture, raises
 from paramiko.sftp_client import SFTPClient
 
@@ -26,6 +27,8 @@ def test_get(sftp_client: SFTPClient, tmp_dir: str):
     assert files_equal(target_fname, __file__)
 
 
+@pytest.mark.skipif(sys.platform == "win32",
+                     reason="Symlinks require SeCreateSymbolicLinkPrivilege on Windows")
 def test_symlink(sftp_client: SFTPClient, tmp_dir: str):
     foo = os.path.join(tmp_dir, "foo")
     bar = os.path.join(tmp_dir, "bar")
@@ -35,6 +38,8 @@ def test_symlink(sftp_client: SFTPClient, tmp_dir: str):
     assert os.path.islink(bar)
 
 
+@pytest.mark.skipif(sys.platform == "win32",
+                     reason="Symlinks require SeCreateSymbolicLinkPrivilege on Windows")
 def test_lstat(sftp_client: SFTPClient, tmp_dir: str):
     foo = os.path.join(tmp_dir, "foo")
     bar = os.path.join(tmp_dir, "bar")

--- a/mockssh/test_streaming.py
+++ b/mockssh/test_streaming.py
@@ -1,5 +1,7 @@
 import random
 import string
+import sys
+import os
 
 from mockssh.server import Server
 
@@ -12,11 +14,23 @@ def random_string() -> str:
     return "".join(random.choice(string.ascii_letters) for _ in range(20))
 
 
+def _cat_command(stderr=False):
+    if sys.platform == "win32":
+        script = os.path.join(os.path.dirname(__file__), "_cat.py")
+        cmd = f'"{sys.executable}" "{script}"'
+        if stderr:
+            cmd += " --stderr"
+        return cmd
+    else:
+        if stderr:
+            return "cat 1>&2"
+        return "cat"
+
+
 def streaming_test(server: Server, command: str, tested_fd: int, number_of_inputs: int=1):
     with server.client(first_user(server)) as c:
         fds = stdin, stdout, stderr = c.exec_command(command)
         for i in range(number_of_inputs):
-            # the new line is necessary as there is buffering until a new line
             channel_input = random_string() + "\n"
             stdin.write(channel_input)
             channel_output = fds[tested_fd].readline()
@@ -24,12 +38,12 @@ def streaming_test(server: Server, command: str, tested_fd: int, number_of_input
 
 
 def test_stdin_to_stdout(server: Server):
-    return streaming_test(server, "cat", 1)
+    return streaming_test(server, _cat_command(), 1)
 
 
 def test_stdin_to_stderr(server: Server):
-    streaming_test(server, "cat 1>&2", 2)
+    streaming_test(server, _cat_command(stderr=True), 2)
 
 
 def test_streaming_output(server: Server):
-    streaming_test(server, "cat", 1, 100)
+    streaming_test(server, _cat_command(), 1, 100)

--- a/mockssh/test_streaming.py
+++ b/mockssh/test_streaming.py
@@ -1,7 +1,6 @@
 import random
 import string
 
-from pytest import mark
 from mockssh.server import Server
 
 
@@ -24,16 +23,13 @@ def streaming_test(server: Server, command: str, tested_fd: int, number_of_input
             assert channel_output == channel_input
 
 
-@mark.fails_on_windows
 def test_stdin_to_stdout(server: Server):
     return streaming_test(server, "cat", 1)
 
 
-@mark.fails_on_windows
 def test_stdin_to_stderr(server: Server):
     streaming_test(server, "cat 1>&2", 2)
 
 
-@mark.fails_on_windows
 def test_streaming_output(server: Server):
     streaming_test(server, "cat", 1, 100)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 addopts = --strict-markers
+markers =
+    fails_on_windows: This test is known to fail on win32 systems.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,2 @@
 [pytest]
 addopts = --strict-markers
-markers =
-    fails_on_windows: This test is known to fail on win32 systems.

--- a/tox.ini
+++ b/tox.ini
@@ -26,4 +26,4 @@ extras =
 commands =
   linux: pytest {posargs}
   mac: pytest {posargs}
-  win: pytest -m "not fails_on_windows" {posargs}
+  win: pytest {posargs}


### PR DESCRIPTION
Add platform detection for Windows/Unix command differences and skip chmod/chown permission checks on Windows where these aren't supported.